### PR TITLE
Add directio options for data write workloads

### DIFF
--- a/bin/perfmon.py
+++ b/bin/perfmon.py
@@ -107,7 +107,9 @@ class PerfMon(object):
 
         # calc. idle time
         total_cpu_time = ncpu * delta[0]
-        delta[4] = total_cpu_time - (delta[1] + delta[3])
+        #woonhak, 4th col is idle, therefore we don't need to crunch this idle number again
+        #in addition, to get the correct number include 'iowait', we should consider 5th col too
+        #delta[4] = total_cpu_time - (delta[1] + delta[3])
 
         # calc cpu utlization
         delta.extend( list( map(lambda x: x/total_cpu_time * 100.0, delta[1:])))
@@ -123,6 +125,18 @@ class PerfMon(object):
             fd.flush()
 
     def _get_cpu_stat(self):
+        #woonhak - According to Linux Documentation, 
+        #/proc/stat is as follows;
+        # - user: normal processes executing in user mode       
+        # - nice: niced processes executing in user mode
+        # - system: processes executing in kernel mode
+        # - idle: twiddling thumbs
+        # - iowait: waiting for I/O to complete
+        # - irq: servicing interrupts
+        # - softirq: servicing softirqs
+        # - steal: involuntary wait
+        # - guest: running a normal guest
+        # - guest_nice: running a niced guest
         p = self._exec_cmd("sudo cat /proc/stat", subprocess.PIPE)
         ncpus = 0
         cpu_stat = []

--- a/src/DWSL.c
+++ b/src/DWSL.c
@@ -12,6 +12,8 @@
 #include <inttypes.h>
 #include "fxmark.h"
 #include "util.h"
+#include <stdlib.h>	/*to use posix_memalign*/
+#include <assert.h> /*to use assert() */
 
 static void set_test_root(struct worker *worker, char *test_root)
 {
@@ -21,7 +23,8 @@ static void set_test_root(struct worker *worker, char *test_root)
 
 static int pre_work(struct worker *worker)
 {
-	char page[PAGE_SIZE];
+  	char *page = NULL;
+	struct bench *bench = worker->bench;
 	char test_root[PATH_MAX];
 	char file[PATH_MAX];
 	int fd, rc = 0;
@@ -35,7 +38,19 @@ static int pre_work(struct worker *worker)
 	snprintf(file, PATH_MAX, "%s/n_jnl_cmt.dat", test_root);
 	if ((fd = open(file, O_CREAT | O_RDWR, S_IRWXU)) == -1)
 		goto err_out;
-	if (write(fd, page, sizeof(page)) == -1)
+
+	/* allocate data buffer aligned with pagesize*/
+	if(posix_memalign((void **)&(worker->page), PAGE_SIZE, PAGE_SIZE))
+	  goto err_out;
+
+	page = worker->page;
+	assert(page);
+
+	/*set flag with O_DIRECT if need*/
+	if(bench->directio && (fcntl(fd, F_SETFL, O_DIRECT)==-1))
+	  goto err_out;
+
+	if (write(fd, page, PAGE_SIZE) != PAGE_SIZE)
 		goto err_out;
 out:
 	/* put fd to worker's private */
@@ -48,15 +63,17 @@ err_out:
 
 static int main_work(struct worker *worker)
 {
-	char page[PAGE_SIZE];
+  	char *page = worker->page;
 	struct bench *bench = worker->bench;
 	int fd, rc = 0;
 	uint64_t iter = 0;
 
+	assert(page);
+
 	/* fsync */
 	fd = (int)worker->private[0];
 	for (iter = 0; !bench->stop; ++iter) {
-	        if (pwrite(fd, page, sizeof(page), 0) == -1)
+	        if (pwrite(fd, page, PAGE_SIZE, 0) != PAGE_SIZE)
 			goto err_out;
 		if (fsync(fd) == -1)
 			goto err_out;

--- a/src/bench.c
+++ b/src/bench.c
@@ -77,7 +77,7 @@ static void sighandler(int x)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-result"
 
-static void worker_main(void *arg) 
+static void worker_main(void *arg)
 {
         struct worker *worker = (struct worker*)arg;
         struct bench *bench = worker->bench;
@@ -100,14 +100,14 @@ static void worker_main(void *arg)
                 while (!bench->start)
                         nop_pause();
         }
-        else {
-                /* are all workers ready? */
-                int i;
-                for (i = 1; i < bench->ncpu; i++) {
-                        struct worker *w = &bench->workers[i];
-                        while (!w->ready)
-                                nop_pause();
-                }
+		else {
+		  /* are all workers ready? */
+		  int i;
+		  for (i = 1; i < bench->ncpu; i++) {
+			struct worker *w = &bench->workers[i];
+			while (!w->ready)
+			  nop_pause();
+		  }
 		/* make things more deterministic */
 		sync();
 
@@ -168,22 +168,22 @@ static void wait(struct bench *bench)
 void run_bench(struct bench *bench)
 {
         int i;
-        for (i = 1; i < bench->ncpu; ++i) {
-                /**
-                 * fork() is intentionally used instead of pthread
-                 * to avoid known scalability bottlenecks 
-                 * of linux virtual memory subsystem. 
-                 */ 
-                pid_t p = fork();
-                if (p < 0)
-                        bench->workers[i].ret = errno;
-                else if (!p) {
-                        worker_main(&bench->workers[i]);
-                        exit(0);
-                }
-        }
-        worker_main(&bench->workers[0]);
-        wait(bench);
+		for (i = 1; i < bench->ncpu; ++i) {
+		  /**
+		   * fork() is intentionally used instead of pthread
+		   * to avoid known scalability bottlenecks 
+		   * of linux virtual memory subsystem. 
+		   */ 
+		  pid_t p = fork();
+		  if (p < 0)
+			bench->workers[i].ret = errno;
+		  else if (!p) {
+			worker_main(&bench->workers[i]);
+			exit(0);
+		  }
+		}
+		worker_main(&bench->workers[0]);
+		wait(bench);
 }
 
 void report_bench(struct bench *bench, FILE *out)

--- a/src/bench.h
+++ b/src/bench.h
@@ -31,6 +31,7 @@ struct bench {
 	int ncpu;
 	int nbg;
 	unsigned int duration;
+	int	directio;
 	struct worker *workers; 
 	struct bench_operations ops;
 	char profile_start_cmd[BENCH_PROFILE_CMD_BYTES];
@@ -52,6 +53,7 @@ struct worker {
 	volatile double   works;
 
 	uint64_t private[WORKER_MAX_PRIVATE];
+	char *page;		/*private data buffer*/
 } CACHELINE_ALIGNED;
 
 struct bench *alloc_bench(int ncpu, int nbg);

--- a/src/fxmark.c
+++ b/src/fxmark.c
@@ -108,6 +108,7 @@ static int parse_option(int argc, char *argv[], struct cmd_opt *opt)
 		{"ncore",     required_argument, 0, 'n'}, 
 		{"nbg",       required_argument, 0, 'g'}, 
 		{"duration",  required_argument, 0, 'd'}, 
+		{"directio",  required_argument, 0, 'D'}, 
 		{"root",      required_argument, 0, 'r'}, 
 		{"profbegin", required_argument, 0, 'b'},
 		{"profend",   required_argument, 0, 'e'},
@@ -122,7 +123,7 @@ static int parse_option(int argc, char *argv[], struct cmd_opt *opt)
 	for(arg_cnt = 0; 1; ++arg_cnt) {
 		int c, idx = 0;
 		c = getopt_long(argc, argv, 
-				"t:n:g:d:r:b:e:l:", options, &idx);
+				"t:n:g:d:D:r:b:e:l:", options, &idx);
 		if (c == -1)
 			break; 
 		switch(c) {
@@ -139,6 +140,13 @@ static int parse_option(int argc, char *argv[], struct cmd_opt *opt)
 			break;
 		case 'd':
 			opt->duration = atoi(optarg);
+			break;
+		case 'D':
+			opt->directio = atoi(optarg);
+#if 0	/*optional debug*/
+			if(opt->directio)
+			  fprintf(stderr, "DirectIO Enabled\n");
+#endif
 			break;
 		case 'r':
 			opt->root = optarg;
@@ -170,6 +178,8 @@ static void usage(FILE *out, const char *myname)
 	fprintf(out, "  --ncore     = number of core\n");
 	fprintf(out, "  --nbg       = number of background worker\n");
 	fprintf(out, "  --duration  = duration in seconds\n");
+	fprintf(out, "  --directio  = file flag set O_DIRECT : 0-false, 1-true\n"
+	             "                                         (only valid for DWxx type)\n");
 	fprintf(out, "  --root      = test root directory\n");
 	fprintf(out, "  --profbegin = profiling start command\n");
 	fprintf(out, "  --profend   = profiling stop command\n");
@@ -181,6 +191,7 @@ static void init_bench(struct bench *bench, struct cmd_opt *opt)
 	struct fx_opt *fx_opt = fx_opt_bench(bench);
 
 	bench->duration = opt->duration;
+	bench->directio = opt->directio;
 	strncpy(bench->profile_start_cmd,
 		opt->profile_start_cmd, BENCH_PROFILE_CMD_BYTES);
 	strncpy(bench->profile_stop_cmd,
@@ -193,7 +204,7 @@ static void init_bench(struct bench *bench, struct cmd_opt *opt)
 
 int main(int argc, char *argv[])
 {
-	struct cmd_opt opt = {NULL, 0, 0, 0, NULL};
+	struct cmd_opt opt = {NULL, 0, 0, 0, 0, NULL};
 	struct bench *bench; 
 
 	/* parse command line options */

--- a/src/fxmark.h
+++ b/src/fxmark.h
@@ -18,6 +18,7 @@ struct cmd_opt {
 	int ncore;
 	int nbg;
 	int duration;
+	int directio;
 	char *root;
 	char *profile_start_cmd;
 	char *profile_stop_cmd;


### PR DESCRIPTION
Add options for directio,
add data buffer and O_DIRECT flag using fcntl()
run-fxmark.py also need to be changed to support DIRECTIO option
fix : perfmon.py has an mistake calculating CPU stat

TODO: plotter.py should take into account directio options.
