### PR TITLE
src/bench.c: mark bench is ready in error path

### DIFF
--- a/src/bench.c
+++ b/src/bench.c
@@ -149,6 +149,10 @@ static void worker_main(void *arg)
         if (bench->ops.post_work)
                 err = bench->ops.post_work(worker);
 err_out:
+        if (!worker->id)
+                bench->start = 1;
+
+        worker->ready = 1;
         worker->ret = err;
         worker->usecs = e_us - s_us;
         wmb();


### PR DESCRIPTION
fxmark will fork several children process, and they will not go through until all processes(parent and children)

However, sometimes the process will reach below code and exit
         /* pre-work */
         if (bench->ops.pre_work) {
                 err = bench->ops.pre_work(worker);
                 if (err) goto err_out;
         }

In this case, this process will not mark start(parent) and ready(child) flag, which may cause
other processes block forever.

root       1750  0.0  0.0  19808  3400 ?        S    14:01   0:00                  \_ /bin/bash /lkp/lizhijian/src/tests/fxmark
root       2007  0.0  0.0  59420 15936 ?        S    14:01   0:00                      \_ python3 ./bin/run-fxmark.py
root       2300  0.0  0.0   4292   772 ?        S    14:01   0:00                          \_ /bin/sh -c PERFMON_LEVEL=0 PERFMON_LDIR=/lkp/benchmarks/fxmark/logs/2019-09-16-14-01-21.395961 PERFMON_LFILE=/lkp/benchmarks/fxmark/logs/2019-09-16-14-01-21.395961/hdd.xfs.DWTL.12.pm /lkp/benchmarks/fxmark/bin/fxmark --type DWTL --ncore 12 --nbg 0 --duration 30 --directio 0 --root /lkp/benchmarks/fxmark/bin/root --profbegin "/lkp/benchmarks/fxmark/bin/perfmon.py start" --profend "/lkp/benchmarks/fxmark/bin/perfmon.py stop" --proflog /lkp/benchmarks/fxmark/logs/2019-09-16-14-01-21.395961/hdd.xfs.DWTL.12.pm
root       2301 99.8  0.0   4264   696 ?        R    14:01   4:00                              \_ /lkp/benchmarks/fxmark/bin/fxmark --type DWTL --ncore 12 --nbg 0 --duration 30 --directio 0 --root /lkp/benchmarks/fxmark/bin/root --profbegin /lkp/benchmarks/fxmark/bin/perfmon.py start --profend /lkp/benchmarks/fxmark/bin/perfmon.py stop --proflog /lkp/benchmarks/fxmark/logs/2019-09-16-14-01-21.395961/hdd.xfs.DWTL.12.pm
root       2302 99.9  0.0   4264    80 ?        R    14:01   4:00                                  \_ /lkp/benchmarks/fxmark/bin/fxmark --type DWTL --ncore 12 --nbg 0 --duration 30 --directio 0 --root /lkp/benchmarks/fxmark/bin/root --profbegin /lkp/benchmarks/fxmark/bin/perfmon.py start --profend /lkp/benchmarks/fxmark/bin/perfmon.py stop --proflog /lkp/benchmarks/fxmark/logs/2019-09-16-14-01-21.395961/hdd.xfs.DWTL.12.pm
root       2303 99.9  0.0   4264    80 ?        R    14:01   4:00                                  \_ /lkp/benchmarks/fxmark/bin/fxmark --type DWTL --ncore 12 --nbg 0 --duration 30 --directio 0 --root /lkp/benchmarks/fxmark/bin/root --profbegin /lkp/benchmarks/fxmark/bin/perfmon.py start --profend /lkp/benchmarks/fxmark/bin/perfmon.py stop --proflog /lkp/benchmarks/fxmark/logs/2019-09-16-14-01-21.395961/hdd.xfs.DWTL.12.pm
root       2304 99.9  0.0   4264    80 ?        R    14:01   4:00                                  \_ /lkp/benchmarks/fxmark/bin/fxmark --type DWTL --ncore 12 --nbg 0 --duration 30 --directio 0 --root /lkp/benchmarks/fxmark/bin/root --profbegin /lkp/benchmarks/fxmark/bin/perfmon.py start --profend /lkp/benchmarks/fxmark/bin/perfmon.py stop --proflog /lkp/benchmarks/fxmark/logs/2019-09-16-14-01-21.395961/hdd.xfs.DWTL.12.pm
root       2305 99.9  0.0   4264    80 ?        R    14:01   4:00                                  \_ /lkp/benchmarks/fxmark/bin/fxmark --type DWTL --ncore 12 --nbg 0 --duration 30 --directio 0 --root /lkp/benchmarks/fxmark/bin/root --profbegin /lkp/benchmarks/fxmark/bin/perfmon.py start --profend /lkp/benchmarks/fxmark/bin/perfmon.py stop --proflog /lkp/benchmarks/fxmark/logs/2019-09-16-14-01-21.395961/hdd.xfs.DWTL.12.pm
root       2306 99.9  0.0   4264    80 ?        R    14:01   4:00                                  \_ /lkp/benchmarks/fxmark/bin/fxmark --type DWTL --ncore 12 --nbg 0 --duration 30 --directio 0 --root /lkp/benchmarks/fxmark/bin/root --profbegin /lkp/benchmarks/fxmark/bin/perfmon.py start --profend /lkp/benchmarks/fxmark/bin/perfmon.py stop --proflog /lkp/benchmarks/fxmark/logs/2019-09-16-14-01-21.395961/hdd.xfs.DWTL.12.pm
root       2307 99.9  0.0   4264    80 ?        R    14:01   4:00                                  \_ /lkp/benchmarks/fxmark/bin/fxmark --type DWTL --ncore 12 --nbg 0 --duration 30 --directio 0 --root /lkp/benchmarks/fxmark/bin/root --profbegin /lkp/benchmarks/fxmark/bin/perfmon.py start --profend /lkp/benchmarks/fxmark/bin/perfmon.py stop --proflog /lkp/benchmarks/fxmark/logs/2019-09-16-14-01-21.395961/hdd.xfs.DWTL.12.pm
root       2308 99.9  0.0   4264    80 ?        R    14:01   4:00                                  \_ /lkp/benchmarks/fxmark/bin/fxmark --type DWTL --ncore 12 --nbg 0 --duration 30 --directio 0 --root /lkp/benchmarks/fxmark/bin/root --profbegin /lkp/benchmarks/fxmark/bin/perfmon.py start --profend /lkp/benchmarks/fxmark/bin/perfmon.py stop --proflog /lkp/benchmarks/fxmark/logs/2019-09-16-14-01-21.395961/hdd.xfs.DWTL.12.pm
root       2309 99.9  0.0   4264    80 ?        R    14:01   4:00                                  \_ /lkp/benchmarks/fxmark/bin/fxmark --type DWTL --ncore 12 --nbg 0 --duration 30 --directio 0 --root /lkp/benchmarks/fxmark/bin/root --profbegin /lkp/benchmarks/fxmark/bin/perfmon.py start --profend /lkp/benchmarks/fxmark/bin/perfmon.py stop --proflog /lkp/benchmarks/fxmark/logs/2019-09-16-14-01-21.395961/hdd.xfs.DWTL.12.pm
root       2310 99.9  0.0   4264    80 ?        R    14:01   4:00                                  \_ /lkp/benchmarks/fxmark/bin/fxmark --type DWTL --ncore 12 --nbg 0 --duration 30 --directio 0 --root /lkp/benchmarks/fxmark/bin/root --profbegin /lkp/benchmarks/fxmark/bin/perfmon.py start --profend /lkp/benchmarks/fxmark/bin/perfmon.py stop --proflog /lkp/benchmarks/fxmark/logs/2019-09-16-14-01-21.395961/hdd.xfs.DWTL.12.pm
root       2311 99.9  0.0   4264    80 ?        R    14:01   4:00                                  \_ /lkp/benchmarks/fxmark/bin/fxmark --type DWTL --ncore 12 --nbg 0 --duration 30 --directio 0 --root /lkp/benchmarks/fxmark/bin/root --profbegin /lkp/benchmarks/fxmark/bin/perfmon.py start --profend /lkp/benchmarks/fxmark/bin/perfmon.py stop --proflog /lkp/benchmarks/fxmark/logs/2019-09-16-14-01-21.395961/hdd.xfs.DWTL.12.pm
root       2312  0.0  0.0      0     0 ?        Z    14:01   0:00                                  \_ [fxmark] <defunct>   <<<< child already exited

Signed-off-by: Li Zhijian <zhijianx.li@intel.com>